### PR TITLE
Run the script without relying on its executable bit being set.

### DIFF
--- a/rocksdb-5.8/CMakeLists.txt
+++ b/rocksdb-5.8/CMakeLists.txt
@@ -126,13 +126,13 @@ string(REGEX REPLACE "[^0-9a-f]+" "" GIT_SHA "${GIT_SHA}")
 
 if(NOT WIN32)
   execute_process(COMMAND
-      "./build_tools/version.sh" "full"
+      "sh" "build_tools/version.sh" "full"
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
       OUTPUT_VARIABLE ROCKSDB_VERSION
   )
   string(STRIP "${ROCKSDB_VERSION}" ROCKSDB_VERSION)
   execute_process(COMMAND
-      "./build_tools/version.sh" "major"
+      "sh" "build_tools/version.sh" "major"
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
       OUTPUT_VARIABLE ROCKSDB_VERSION_MAJOR
   )


### PR DESCRIPTION
Addresses https://github.com/TerrorJack/direct-rocksdb/issues/2 .
Workaround for https://github.com/haskell/tar/issues/25 .